### PR TITLE
Remove unnecessary FIXME comment in token-regexp

### DIFF
--- a/src/analysis/tokenizers.lisp
+++ b/src/analysis/tokenizers.lisp
@@ -54,7 +54,6 @@
   ())
 
 (defmethod token-regexp ((self letter-tokenizer))
-  ;; FIXME: [a-zA-Z] isn't quite the same as Perl's [[alpha]], is it?
   (cl-ppcre:create-scanner "[a-zA-Z]+" :multi-line-mode T))
 
 (defclass lowercase-tokenizer (letter-tokenizer)


### PR DESCRIPTION
The FIXME asked, "[a-zA-Z] isn't quite the same as Perl's [[alpha]], is it?". But the perlrecharclass manpage defines alpha as "Any alphabetical character ('[A-Za-z]')." So no fix needed here. For Unicode things are different, but that'd require a change to more than just here.
