### PR TITLE
Basic field sorting fixes.

### DIFF
--- a/src/search/hit-queue.lisp
+++ b/src/search/hit-queue.lisp
@@ -16,7 +16,7 @@
   (with-slots (fields reader) queue
     (flet ((hit-document-value (hit value)
              (let ((field (document-field 
-                            (get-document reader (doc hit1))
+                            (get-document reader (doc hit))
                             value)))
                (and 
                  field 
@@ -30,9 +30,8 @@
                   (value-2 (hit-document-value hit2 name)))
               (or 
                 (not value-1)
-                (not (string= value-1 value-2))
                 (funcall 
                   (if reverse-p 
-                    #'string>
-                    #'string<)
+                    #'string<
+                    #'string>)
                   value-1 value-2)))))))))

--- a/src/search/index-searcher.lisp
+++ b/src/search/index-searcher.lisp
@@ -60,7 +60,7 @@
 	 (max-size (+ first-doc num-docs))
 	 (sort (getf options :sort)))
     (when (and sort (not (typep sort 'sort)))
-      (setf sort (make-instance 'sort :sort sort)))
+      (setf sort (make-instance 'sort :fields sort)))
     (when (<= num-docs 0)
       (error ":num-docs must be greater than zero to run a search."))
     (when (< first-doc 0)


### PR DESCRIPTION
Fixes the ability to do some basic field sorting like
```(montezuma:search *index* "title:wathever" :sort '("title"))```