### PR TITLE
Fix tests

### DIFF
--- a/src/index/index.lisp
+++ b/src/index/index.lisp
@@ -351,7 +351,6 @@
   (num-docs (reader self)))
 
 (defmethod add-indexes ((self index) &rest indexes)
-  (declare (cl:optimize (debug 3)))
   (when (> (length indexes) 0)
     (when (typep (elt indexes 0) 'index)
       (setf indexes (map 'list #'reader indexes)))

--- a/src/index/index.lisp
+++ b/src/index/index.lisp
@@ -351,9 +351,10 @@
   (num-docs (reader self)))
 
 (defmethod add-indexes ((self index) &rest indexes)
+  (declare (cl:optimize (debug 3)))
   (when (> (length indexes) 0)
     (when (typep (elt indexes 0) 'index)
-      (setf indexes (map 'vector #'reader indexes)))
+      (setf indexes (map 'list #'reader indexes)))
     (cond ((typep (elt indexes 0) 'index-reader)
 	   (let ((reader (reader self)))
 	     (setf indexes (remove reader indexes)))

--- a/tests/unit/analysis/tc-standard-analyzer.lisp
+++ b/tests/unit/analysis/tc-standard-analyzer.lisp
@@ -2,7 +2,7 @@
 
 (deftestfun test-standard-analyzer
   (with-input-from-string (input "D.Ba_l-n@gma-l.com AB&Sons Toys'r'us you're she's, #$%^$%*& job@dot I.B.M. the an AnD THEIR")
-    (let* ((analyzer (make-instance 'standard-analyzer))
+    (let* ((analyzer (make-instance 'standard-analyzer :stop-words nil))
 	   (token-stream (token-stream analyzer "field" input)))
       (test standard-analyzer-1 (next-token token-stream) (make-token "d.ba_l-n@gma-l.com" 0 18) #'token=)
       (test standard-analyzer-2 (next-token token-stream) (make-token "ab&sons" 19 26) #'token=)

--- a/tests/unit/query-parser/tc-query-parser.lisp
+++ b/tests/unit/query-parser/tc-query-parser.lisp
@@ -82,6 +82,7 @@
 (defun check-query-parse (query-string expected-parse-tree)
   (atest check-query-parse
 	 (parse (make-instance 'test-query-parser
+                               :analyzer (make-instance 'standard-analyzer :stop-words nil)
 			       :fields '("f1" "f2"))
 		query-string)
 	 expected-parse-tree
@@ -104,7 +105,7 @@
 		(:BOOLEAN-CLAUSE :SHOULD-OCCUR (:TERM-QUERY "*" "def"))))) 
 	     ("john's"
 	      (:BOOLEAN-QUERY ((:BOOLEAN-CLAUSE :SHOULD-OCCUR (:TERM-QUERY "*" "john")))))
-	     ("john's email is jjwiseman@yahoo.com mail-to"
+	     ("john's email is jjwiseman@yahoo.com \"mail to\""
 	      (:BOOLEAN-QUERY
 	       ((:BOOLEAN-CLAUSE :SHOULD-OCCUR (:TERM-QUERY "*" "john"))
 		(:BOOLEAN-CLAUSE :SHOULD-OCCUR (:TERM-QUERY "*" "email"))


### PR DESCRIPTION
Two tests were failing due to stopwords functionality.

I am not sure about `add-indexes` method. I jut don't know. `(elt indexes 0)` was failing because `indexes` was a vector instead of a list, but i'm pretty sure `elt` should work for vectors too. :scream: 
¿Ideas?