### PR TITLE
Don't skip stop words in TEST-QUERY-PARSER

### DIFF
--- a/tests/unit/query-parser/tc-query-parser.lisp
+++ b/tests/unit/query-parser/tc-query-parser.lisp
@@ -2,7 +2,9 @@
 
 
 (defclass test-query-parser (query-parser)
-  ())
+  ()
+  (:default-initargs
+   :analyzer (make-instance 'standard-analyzer :stop-words nil)))
 
 
 (defmethod $add-and-clause ((parser test-query-parser) clauses clause)


### PR DESCRIPTION
Query parser tests are written assuming that behaviour. For example the parse-tree for `"john's email is jjwiseman@yahoo.com mail-to"` expands to

```lisp
(:BOOLEAN-QUERY
	       ((:BOOLEAN-CLAUSE :SHOULD-OCCUR (:TERM-QUERY "*" "john"))
		(:BOOLEAN-CLAUSE :SHOULD-OCCUR (:TERM-QUERY "*" "email"))
		(:BOOLEAN-CLAUSE :SHOULD-OCCUR (:TERM-QUERY "*" "")) ; <=
		(:BOOLEAN-CLAUSE :SHOULD-OCCUR (:TERM-QUERY "*" "jjwiseman@yahoo.com"))
		(:BOOLEAN-CLAUSE :SHOULD-OCCUR
				 (:PHRASE-QUERY "*" (("mail" . 1) ("to" . 1))))))

;; instead of 

(:BOOLEAN-QUERY
	       ((:BOOLEAN-CLAUSE :SHOULD-OCCUR (:TERM-QUERY "*" "john"))
		(:BOOLEAN-CLAUSE :SHOULD-OCCUR (:TERM-QUERY "*" "email"))
		(:BOOLEAN-CLAUSE :SHOULD-OCCUR (:TERM-QUERY "*" "is")) ; <=
		(:BOOLEAN-CLAUSE :SHOULD-OCCUR (:TERM-QUERY "*" "jjwiseman@yahoo.com"))
		(:BOOLEAN-CLAUSE :SHOULD-OCCUR
				 (:PHRASE-QUERY "*" (("mail" . 1) ("to" . 1))))))
```

because is a stop word

cf. #6