### PR TITLE
(index.lisp) add-indexes: Ensure (safety 3)

### DIFF
--- a/src/index/index.lisp
+++ b/src/index/index.lisp
@@ -351,18 +351,19 @@
   (num-docs (reader self)))
 
 (defmethod add-indexes ((self index) &rest indexes)
-  (when (> (length indexes) 0)
-    (when (typep (elt indexes 0) 'index)
-      (setf indexes (map 'vector #'reader indexes)))
-    (cond ((typep (elt indexes 0) 'index-reader)
-	   (let ((reader (reader self)))
-	     (setf indexes (remove reader indexes)))
-	   (add-indexes-readers (writer self) indexes))
-	  ((typep (elt indexes 0) 'directory)
-	   (setf indexes (remove (slot-value self 'dir) indexes))
-	   (apply #'add-indexes (writer self) indexes))
-	  (T
-	   (error "Unknown index type ~S when trying to merge indexes." (elt indexes 0))))))
+  (let ((indexes indexes))
+    (when (> (length indexes) 0)
+      (when (typep (elt indexes 0) 'index)
+        (setf indexes (map 'vector #'reader indexes)))
+      (cond ((typep (elt indexes 0) 'index-reader)
+             (let ((reader (reader self)))
+               (setf indexes (remove reader indexes)))
+             (add-indexes-readers (writer self) indexes))
+            ((typep (elt indexes 0) 'directory)
+             (setf indexes (remove (slot-value self 'dir) indexes))
+             (apply #'add-indexes (writer self) indexes))
+            (T
+             (error "Unknown index type ~S when trying to merge indexes." (elt indexes 0)))))))
 
 (defgeneric persist (index directory &key create-p))
 


### PR DESCRIPTION
Although modifying &REST lambda variables is not strictly forbidden by
the CLHS, it is discouraged[1]. When compiling under safety values less
than 3 SBCL assumes the &REST parameter to be a list, so calls to elt are
specialized to the list variation.

[1]: "There is a particular problem with &REST lambda variables, which
are always bound to a value of type LIST."
cf. http://www.lispworks.com/documentation/HyperSpec/Issues/iss178_w.htm

A better solution in the long term would be to rewrite add-indexes
